### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@
     module.exports = todoStore;
 ```
 
-`Tuxx` provides powerful opinionated `React` classes that make connecting with your stores, sharing methods with child components, and building high performance components a synch.
+`Tuxx` provides powerful opinionated `React` classes that make connecting with your stores, sharing methods with child components, and building high performance components a cinch.
 
 A high performance component:
 


### PR DESCRIPTION
Assuming that 'synch' is supposed to mean "easy", it should be spelled 'cinch'.

![image](https://cloud.githubusercontent.com/assets/7017045/6140000/53812f40-b147-11e4-8381-a80eb8428ba2.png)

![image](https://cloud.githubusercontent.com/assets/7017045/6139989/365c4706-b147-11e4-9826-ef919c7984bf.png)
