### PR TITLE
Update tuxx to be compatable with React 0.13.1.

### DIFF
--- a/Router/DefaultRoute.js
+++ b/Router/DefaultRoute.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/components/DefaultRoute');
+module.exports = require('react-router/lib/components/DefaultRoute');

--- a/Router/HashLocation.js
+++ b/Router/HashLocation.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/locations/HashLocation');
+module.exports = require('react-router/lib/locations/HashLocation');

--- a/Router/History.js
+++ b/Router/History.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/utils/History');
+module.exports = require('react-router/lib/History');

--- a/Router/HistoryLocation.js
+++ b/Router/HistoryLocation.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/locations/HistoryLocation');
+module.exports = require('react-router/lib/locations/HistoryLocation');

--- a/Router/ImitateBrowserBehavior.js
+++ b/Router/ImitateBrowserBehavior.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/behaviors/ImitateBrowserBehavior');
+module.exports = require('react-router/lib/behaviors/ImitateBrowserBehavior');

--- a/Router/Link.js
+++ b/Router/Link.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/components/Link');
+module.exports = require('react-router/lib/components/Link');

--- a/Router/Navigation.js
+++ b/Router/Navigation.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/mixins/Navigation');
+module.exports = require('react-router/lib/Navigation');

--- a/Router/NotFoundRoute.js
+++ b/Router/NotFoundRoute.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/components/NotFoundRoute');
+module.exports = require('react-router/lib/components/NotFoundRoute');

--- a/Router/Redirect.js
+++ b/Router/Redirect.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/components/Redirect');
+module.exports = require('react-router/lib/components/Redirect');

--- a/Router/RefreshLocation.js
+++ b/Router/RefreshLocation.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/locations/RefreshLocation');
+module.exports = require('react-router/lib/locations/RefreshLocation');

--- a/Router/Route.js
+++ b/Router/Route.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/components/Route');
+module.exports = require('react-router/lib/components/Route');

--- a/Router/RouteHandler.js
+++ b/Router/RouteHandler.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/components/RouteHandler');
+module.exports = require('react-router/lib/components/RouteHandler');

--- a/Router/ScrollToBehavior.js
+++ b/Router/ScrollToBehavior.js
@@ -1,1 +1,0 @@
-module.exports = require('react-router/modules/behaviors/ScrollToTopBehavior');

--- a/Router/ScrollToTopBehavior.js
+++ b/Router/ScrollToTopBehavior.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/behaviors/ScrollToTopBehavior');

--- a/Router/State.js
+++ b/Router/State.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/mixins/State');
+module.exports = require('react-router/lib/State');

--- a/Router/StaticLocation.js
+++ b/Router/StaticLocation.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/locations/StaticLocation');

--- a/Router/TestLocation.js
+++ b/Router/TestLocation.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/locations/TestLocation');

--- a/Router/create.js
+++ b/Router/create.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/utils/createRouter');
+module.exports = require('react-router/lib/createRouter');

--- a/Router/createDefaultRoute.js
+++ b/Router/createDefaultRoute.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/Route').createDefaultRoute;

--- a/Router/createNotFoundRoute.js
+++ b/Router/createNotFoundRoute.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/Route').createNotFoundRoute;

--- a/Router/createRedirect.js
+++ b/Router/createRedirect.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/Route').createRedirect;

--- a/Router/createRoute.js
+++ b/Router/createRoute.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/Route').createRoute;

--- a/Router/createRoutesFromReactChildren.js
+++ b/Router/createRoutesFromReactChildren.js
@@ -1,0 +1,1 @@
+module.exports = require('react-router/lib/createRoutesFromReactChildren');

--- a/Router/run.js
+++ b/Router/run.js
@@ -1,1 +1,1 @@
-module.exports = require('react-router/modules/utils/runRouter');
+module.exports = require('react-router/lib/runRouter');

--- a/__tests__/TuxxModules-test.js
+++ b/__tests__/TuxxModules-test.js
@@ -45,8 +45,34 @@ describe('Individual Tuxx Modules', function () {
   });
 
   describe('Router', function () {
-    it('should expose only the specific router component that the user requires in', function () {
+    it('should expose only the specific router component or method that the user requires in', function () {
+      expect(require('tuxx/Router/DefaultRoute')).toBe(require('react-router').DefaultRoute);
+      expect(require('tuxx/Router/Link')).toBe(require('react-router').Link);
+      expect(require('tuxx/Router/NotFoundRoute')).toBe(require('react-router').NotFoundRoute);
+      expect(require('tuxx/Router/Redirect')).toBe(require('react-router').Redirect);
       expect(require('tuxx/Router/Route')).toBe(require('react-router').Route);
+      expect(require('tuxx/Router/RouteHandler')).toBe(require('react-router').RouteHandler);
+
+      expect(require('tuxx/Router/HashLocation')).toBe(require('react-router').HashLocation);
+      expect(require('tuxx/Router/HistoryLocation')).toBe(require('react-router').HistoryLocation);
+      expect(require('tuxx/Router/RefreshLocation')).toBe(require('react-router').RefreshLocation);
+      expect(require('tuxx/Router/StaticLocation')).toBe(require('react-router').StaticLocation);
+      expect(require('tuxx/Router/TestLocation')).toBe(require('react-router').TestLocation);
+
+      expect(require('tuxx/Router/ImitateBrowserBehavior')).toBe(require('react-router').ImitateBrowserBehavior);
+      expect(require('tuxx/Router/ScrollToTopBehavior')).toBe(require('react-router').ScrollToTopBehavior);
+
+      expect(require('tuxx/Router/History')).toBe(require('react-router').History);
+      expect(require('tuxx/Router/Navigation')).toBe(require('react-router').Navigation);
+      expect(require('tuxx/Router/State')).toBe(require('react-router').State);
+
+      expect(require('tuxx/Router/createRoute')).toBe(require('react-router').createRoute);
+      expect(require('tuxx/Router/createDefaultRoute')).toBe(require('react-router').createDefaultRoute);
+      expect(require('tuxx/Router/createNotFoundRoute')).toBe(require('react-router').createNotFoundRoute);
+      expect(require('tuxx/Router/createRedirect')).toBe(require('react-router').createRedirect);
+      expect(require('tuxx/Router/createRoutesFromReactChildren')).toBe(require('react-router').createRoutesFromReactChildren);
+      expect(require('tuxx/Router/create')).toBe(require('react-router').create);
+      expect(require('tuxx/Router/run')).toBe(require('react-router').run);
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tuxx",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Framework built on React and Flux",
   "main": "Tuxedo.js",
   "scripts": {
@@ -43,8 +43,8 @@
     "events": "^1.0.2",
     "flux": "^2.0.1",
     "object-assign": "^2.0.0",
-    "react": "^0.12.2",
-    "react-router": "^0.11.6",
+    "react": "^0.13.1",
+    "react-router": "^0.13.2",
     "react-validating-form": "^0.1.1",
     "reactify": "^0.17.1",
     "watchify": "^2.2.1"

--- a/src/TuxxGetOwnerPropsMixin.js
+++ b/src/TuxxGetOwnerPropsMixin.js
@@ -5,9 +5,12 @@
 module.exports = {
   //add property under componentWillMount so that other lifecycle methods will be able to access it
   componentWillMount: function () {
-    var owner = this._owner;
+    var owner = this._reactInternalInstance._currentElement._owner;
     //if the owner is an OwnerComponent get its __tuxxOwnerProps__, otherwise get its nearestOwnerProps
     while (owner) {
+      // if there is an owner get its _instance
+      owner = owner._instance;
+
       //approach takes advantage of cascading order of componentWillMount invocations.  Since componentWillMount is called on an owner before its ownee, a component can just read from its owner to get the needed props
       var nearestOwnerProps = owner.nearestOwnerProps;
       if (owner.__tuxxIsOwnerComponent__) {
@@ -17,7 +20,7 @@ module.exports = {
         this.nearestOwnerProps = nearestOwnerProps;
         break;
       }
-      owner = owner._owner;
+      owner = owner._reactInternalInstance._currentElement._owner;
     }
     //if this component is an owner component and its ownerProps have not been registered already
     if (this.__tuxxIsOwnerComponent__ && !this.__tuxxOwnerProps__) {

--- a/src/TuxxPropTypeCheckerMixin.js
+++ b/src/TuxxPropTypeCheckerMixin.js
@@ -8,14 +8,14 @@ module.exports = {
     //if nearestOwnerPropTypes is defined
     if (nearestOwnerPropTypes) {
       //check the nearestOwnerProps
-      this._checkPropTypes(nearestOwnerPropTypes, this.nearestOwnerProps, 'nearestOwnerProps');
+      this._reactInternalInstance._checkPropTypes(nearestOwnerPropTypes, this.nearestOwnerProps, 'nearestOwnerProps');
     }
     //get the anyPropTypes from the component
     var anyPropTypes = this.anyPropTypes;
     //if anyPropTypes is defined
     if (anyPropTypes) {
       //check both the nearestOwnerProps and props. Note that this.props is passed in last so that it overwrites matching keys with this.nearestOwnerProps
-      this._checkPropTypes(anyPropTypes ,assign({}, this.nearestOwnerProps, this.props), 'props or nearestOwnerProps');
+      this._reactInternalInstance._checkPropTypes(anyPropTypes ,assign({}, this.nearestOwnerProps, this.props), 'props or nearestOwnerProps');
     }
   }
 };

--- a/src/__tests__/TuxxGetOwnerPropsMixin-test.js
+++ b/src/__tests__/TuxxGetOwnerPropsMixin-test.js
@@ -10,7 +10,8 @@ describe('getOwnerPropsMixin', function () {
   beforeEach(function () {
     //reset getOwnerPropsMixin
     getOwnerPropsMixin = require(moduleToTest);
-    //construct chain of _owner objects tO = tuxxOwner
+    //construct chain of _reactInternalInstance._currentElement._owner objects tO = tuxxOwner
+    //and set the _instance property on each node to refer to itself
     /*
                 [root1 tO]
               /            \
@@ -20,37 +21,73 @@ describe('getOwnerPropsMixin', function () {
     */
     //reset Owners and Ownees
     root1Owner = {
-      __tuxxIsOwnerComponent__: true,
+      _reactInternalInstance: {
+        _currentElement: {
+          _owner: null
+        }
+      },
       mockOwnerProps: {},
+      __tuxxIsOwnerComponent__: true,
       registerOwnerProps: function () {
         return this.mockOwnerProps;
       }
     };
+    root1Owner._instance = root1Owner;
+
     branch1Owner = {
-      _owner: root1Owner,
-      __tuxxIsOwnerComponent__: true,
+      _reactInternalInstance: {
+        _currentElement: {
+          _owner: root1Owner
+        }
+      },
       mockOwnerProps: {},
+      __tuxxIsOwnerComponent__: true,
       registerOwnerProps: function () {
         return this.mockOwnerProps;
       }
     };
+    branch1Owner._instance = branch1Owner;
+
     branch2Ownee = {
-      _owner: root1Owner
+      _reactInternalInstance: {
+        _currentElement: {
+          _owner: root1Owner
+        }
+      }
     };
+    branch2Ownee._instance = branch2Ownee;
+
     leaf11Ownee = {
-      _owner: branch1Owner
+      _reactInternalInstance: {
+        _currentElement: {
+          _owner: branch1Owner
+        }
+      }
     };
+    leaf11Ownee._instance = leaf11Ownee;
+
     leaf12Owner = {
-      _owner: branch1Owner,
-      __tuxxIsOwnerComponent__: true,
+      _reactInternalInstance: {
+        _currentElement: {
+          _owner: branch1Owner
+        }
+      },
       mockOwnerProps: {},
+      __tuxxIsOwnerComponent__: true,
       registerOwnerProps: function () {
         return this.mockOwnerProps;
       }
     };
+    leaf12Owner._instance = leaf12Owner;
+
     leaf21Ownee = {
-      _owner: branch2Ownee
+      _reactInternalInstance: {
+        _currentElement: {
+          _owner: branch2Ownee
+        }
+      },
     };
+    leaf21Ownee._instance = leaf21Ownee;
   });
 
   it('should properly pass down the ownerProps to nearestOwnerProps from owner to owner and owner to ownee on componentWillMount', function () {

--- a/src/__tests__/TuxxPropTypeCheckerMixin-test.js
+++ b/src/__tests__/TuxxPropTypeCheckerMixin-test.js
@@ -10,19 +10,21 @@ describe('propTypeCheckerMixin', function () {
     propTypeCheckerMixin = require(moduleToTest);
     mockComponent = {
       //provide mock function to be invoked on componentWillMount
-      _checkPropTypes: jest.genMockFn()
+      _reactInternalInstance: {
+        _checkPropTypes: jest.genMockFn()
+      }
     };
   });
 
-  it('should submit component.nearestOwnerPropTypes and nearestOwnerProps to _checkPropTypes on componentWillMount if nearestOwnerPropTypes is defined on the component', function () {
+  it('should submit component.nearestOwnerPropTypes and nearestOwnerProps to _reactInternalInstance._checkPropTypes on componentWillMount if nearestOwnerPropTypes is defined on the component', function () {
     //define nearestOwnerPropTypes on the component
     mockComponent.nearestOwnerPropTypes = {};
     //define nearestOwnerProps on the component
     mockComponent.nearestOwnerProps = {};
     //invoke componentWillMount passing in the mockComponent as the context
     propTypeCheckerMixin.componentWillMount.call(mockComponent);
-    //check inputs to _checkPropTypes
-    var checkPropTypesCall = mockComponent._checkPropTypes.mock.calls[0];
+    //check inputs to _reactInternalInstance._checkPropTypes
+    var checkPropTypesCall = mockComponent._reactInternalInstance._checkPropTypes.mock.calls[0];
     expect(checkPropTypesCall[0]).toBe(mockComponent.nearestOwnerPropTypes);
     expect(checkPropTypesCall[1]).toBe(mockComponent.nearestOwnerProps);
     expect(checkPropTypesCall[2]).toBe('nearestOwnerProps');
@@ -42,8 +44,8 @@ describe('propTypeCheckerMixin', function () {
     };
     //invoke componentWillMount passing in the mockComponent as the context
     propTypeCheckerMixin.componentWillMount.call(mockComponent);
-    //check inputs to _checkPropTypes
-    var checkPropTypesCall = mockComponent._checkPropTypes.mock.calls[0];
+    //check inputs to _reactInternalInstance._checkPropTypes
+    var checkPropTypesCall = mockComponent._reactInternalInstance._checkPropTypes.mock.calls[0];
     expect(checkPropTypesCall[0]).toBe(mockComponent.anyPropTypes);
     expect(checkPropTypesCall[1].prop1).toBe(mockComponent.nearestOwnerProps.prop1);
     //props should overwrite nearestOwnerProps


### PR DESCRIPTION
- Update react and react-router dependency versions in package.json.
- Update tuxx Router components to use the updated react-router API.
- Expose remainder of react-router API in Tuxx Router implementation.
- Expand Tuxx Router tests to test all react-router components that are exposed.
- Update TuxxPropTypeCheckerMixin and associated tests to use new location of _checkPropTypes.
- Update TuxxGetOwnerPropsMixin and tests to use updated React internal API.
- Update tuxx version number in package.json.
